### PR TITLE
Add URL resolution

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"github.com/fabiante/yaus/app"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 func SetupHTTPServer(api *gin.Engine, service *app.Service) *gin.Engine {
-	api.POST("shorten", func(ctx *gin.Context) {
+	api.POST("/shorten", func(ctx *gin.Context) {
 		var url string
 		err := ctx.BindJSON(&url)
 		if err != nil {
@@ -27,6 +29,27 @@ func SetupHTTPServer(api *gin.Engine, service *app.Service) *gin.Engine {
 		}
 
 		ctx.JSON(200, shortened)
+	})
+
+	api.GET("/s/:short", func(ctx *gin.Context) {
+		short := ctx.Param("short")
+		if short == "" {
+			_ = ctx.AbortWithError(400, fmt.Errorf("no short to resolve"))
+			return
+		}
+
+		shortened, err := service.Resolve(short)
+		if err != nil {
+			if errors.Is(err, app.ErrInvalidUrl) {
+				_ = ctx.AbortWithError(400, err)
+				return
+			} else {
+				_ = ctx.AbortWithError(500, err)
+				return
+			}
+		}
+
+		ctx.Redirect(http.StatusPermanentRedirect, shortened)
 	})
 
 	return api

--- a/app/service.go
+++ b/app/service.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"strings"
+	"sync"
 )
 
 type Service struct {
+	urls     map[uuid.UUID]string
+	urlsLock sync.RWMutex
 }
 
 func NewService() *Service {
-	return &Service{}
+	return &Service{
+		urls: make(map[uuid.UUID]string),
+	}
 }
 
 var (
@@ -35,7 +40,9 @@ func (s *Service) ShortenURL(input string) (string, error) {
 	// generate a random id for this url
 	id := uuid.New()
 
-	// todo: actually store ID + input URL so that they can be resolved later - write test first
+	s.urlsLock.Lock()
+	s.urls[id] = input
+	s.urlsLock.Unlock()
 
 	return id.String(), nil
 }

--- a/bdd/drivers/direct.go
+++ b/bdd/drivers/direct.go
@@ -13,3 +13,7 @@ func NewDirectDriver(service *app.Service) *DirectDriver {
 func (d *DirectDriver) ShortenURL(input string) (string, error) {
 	return d.service.ShortenURL(input)
 }
+
+func (d *DirectDriver) Resolve(short string) (string, error) {
+	return d.service.Resolve(short)
+}

--- a/bdd/drivers/http.go
+++ b/bdd/drivers/http.go
@@ -14,9 +14,18 @@ type HTTPDriver struct {
 }
 
 func NewHTTPDriver(baseURL string) *HTTPDriver {
+	// Custom client which does not follow redirects - required since
+	// the API makes use of 3xx redirections.
+	client := &http.Client{
+		Transport: http.DefaultTransport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
 	return &HTTPDriver{
 		BaseURL: baseURL,
-		client:  http.DefaultClient,
+		client:  client,
 	}
 }
 

--- a/bdd/drivers/http.go
+++ b/bdd/drivers/http.go
@@ -10,14 +10,18 @@ import (
 
 type HTTPDriver struct {
 	BaseURL string
+	client  *http.Client
 }
 
 func NewHTTPDriver(baseURL string) *HTTPDriver {
-	return &HTTPDriver{BaseURL: baseURL}
+	return &HTTPDriver{
+		BaseURL: baseURL,
+		client:  http.DefaultClient,
+	}
 }
 
 func (d *HTTPDriver) ShortenURL(input string) (string, error) {
-	res, err := http.Post(fmt.Sprintf("%s/shorten", d.BaseURL), "application/json", toJSONReader(input))
+	res, err := d.client.Post(fmt.Sprintf("%s/shorten", d.BaseURL), "application/json", toJSONReader(input))
 	if err != nil {
 		return "", err
 	}

--- a/bdd/drivers/http.go
+++ b/bdd/drivers/http.go
@@ -39,6 +39,10 @@ func (d *HTTPDriver) ShortenURL(input string) (string, error) {
 	return url, nil
 }
 
+func (d *HTTPDriver) Resolve(short string) (string, error) {
+	panic("driver not yet implemented")
+}
+
 func toJSON(data any) []byte {
 	bytes, err := json.Marshal(data)
 	if err != nil {

--- a/bdd/drivers/http.go
+++ b/bdd/drivers/http.go
@@ -53,7 +53,20 @@ func (d *HTTPDriver) ShortenURL(input string) (string, error) {
 }
 
 func (d *HTTPDriver) Resolve(short string) (string, error) {
-	panic("driver not yet implemented")
+	res, err := d.client.Get(fmt.Sprintf("%s/s/%s", d.BaseURL, short))
+	if err != nil {
+		return "", err
+	}
+	switch res.StatusCode {
+	case http.StatusPermanentRedirect:
+		break
+	default:
+		return "", fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+
+	url := res.Header.Get("Location")
+
+	return url, nil
 }
 
 func toJSON(data any) []byte {

--- a/bdd/drivers/http.go
+++ b/bdd/drivers/http.go
@@ -30,7 +30,7 @@ func (d *HTTPDriver) ShortenURL(input string) (string, error) {
 		break
 	case 400:
 		return "", fmt.Errorf("invalid url (api responded with status 400)")
-	case 500:
+	default:
 		return "", fmt.Errorf("unexpected status %d", res.StatusCode)
 	}
 

--- a/bdd/specs/interface.go
+++ b/bdd/specs/interface.go
@@ -2,4 +2,5 @@ package specs
 
 type Service interface {
 	ShortenURL(input string) (string, error)
+	Resolve(short string) (string, error)
 }

--- a/bdd/specs/tests.go
+++ b/bdd/specs/tests.go
@@ -8,10 +8,17 @@ import (
 
 func TestAll(t *testing.T, service Service) {
 	t.Run("feature: shortening a link link", func(t *testing.T) {
-		t.Run("given a valid URL will produce a shorter URL", func(t *testing.T) {
+		t.Run("given a valid URL will produce a shorter URL which resolves to the original", func(t *testing.T) {
+			// create a shortened link
 			input := "https://en.wikipedia.org/wiki/Go_(programming_language)#Types"
 			url, err := service.ShortenURL(input)
 			requireShortenedURL(t, err, url, input)
+
+			// use the shortened link to ensure it resolves to the original input
+			resolved, err := service.Resolve(url)
+			require.NoError(t, err)
+			require.NotEmpty(t, resolved)
+			require.Equal(t, input, resolved)
 		})
 
 		t.Run("given invalid input will error out", func(t *testing.T) {


### PR DESCRIPTION
This PR introduces the actual purpose of a URL shortener: The actual resolution of shorter URLs to the original, often times longer URL.

The test specification has been extended by asserting that the created short resolves to the original URL.

The http api makes use of permanent http redirects on the given endpoint.